### PR TITLE
feat/event sentiment summary

### DIFF
--- a/src/api/EventApi.js
+++ b/src/api/EventApi.js
@@ -10,4 +10,8 @@ export const EventApi = {
     async getAllEvents() {
         return axios.get(`${API_BASE_URL}`);
     },
+
+    async getSentimentSummary(eventId) {
+        return axios.get(`${API_BASE_URL}/${eventId}/summary`);
+    },
 }

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -1,14 +1,17 @@
 import { FeedbackField } from "./FeedbackField";
+import { SentimentSummary } from "./SentimentSummary";
 
 export function EventCard({ id, title, description }) {
     return (
         <div className="border rounded p-4 shadow-sm bg-white">
+            
             <h2 className="text-lg font-semibold textr-teal-700">
                 {title}
             </h2>
             <p className="text-gray-700 mt-1">
                 {description}
             </p>
+            <SentimentSummary eventId={id}/>
             <FeedbackField eventId={id}/>
         </div>
     )

--- a/src/components/SentimentSummary.jsx
+++ b/src/components/SentimentSummary.jsx
@@ -1,0 +1,22 @@
+import { useSentimentSummary } from "../hooks/useSentimentSummary";
+
+export function SentimentSummary({ eventId }) {
+    const {summary, loading, error} = useSentimentSummary(eventId);
+
+    if (loading) return <p>Loading sentiment summary…</p>;
+    if (error) return <p className="text-red-600">Error: {error}</p>;
+
+    return (
+        <div className="flex items-center gap-3 text-gray-700 my-2">
+            <div className="flex items-center gap-1">
+                <span role="img" aria-label="positive" >👍</span> {summary.positiveCount}
+            </div>
+            <div className="flex items-center gap-1">
+                <span role="img" aria-label="neutral" >😐</span> {summary.neutralCount}
+            </div>
+            <div className="flex items-center gap-1">
+                <span role="img" aria-label="negative" >👎</span> {summary.negativeCount}
+            </div>
+        </div>
+    )
+}

--- a/src/components/SentimentSummary.jsx
+++ b/src/components/SentimentSummary.jsx
@@ -9,13 +9,13 @@ export function SentimentSummary({ eventId }) {
     return (
         <div className="flex items-center gap-3 text-gray-700 my-2">
             <div className="flex items-center gap-1">
-                <span role="img" aria-label="positive" >👍</span> {summary.positiveCount}
+                <span role="img" aria-label="positive" >😍</span> {summary.positiveCount}
             </div>
             <div className="flex items-center gap-1">
                 <span role="img" aria-label="neutral" >😐</span> {summary.neutralCount}
             </div>
             <div className="flex items-center gap-1">
-                <span role="img" aria-label="negative" >👎</span> {summary.negativeCount}
+                <span role="img" aria-label="negative" >😡</span> {summary.negativeCount}
             </div>
         </div>
     )

--- a/src/hooks/useSentimentSummary.js
+++ b/src/hooks/useSentimentSummary.js
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+import { EventApi } from "../api/EventApi";
+
+export function useSentimentSummary(eventId) {
+    const [summary, setSummary] = useState({
+        positiveCount: 0,
+        neutralCount:  0,
+        negativeCount: 0,
+    });
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        async function fetchSummary() {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await EventApi.getSentimentSummary(eventId);
+                setSummary(response.data);
+            } catch (err) {
+                setError(err?.response?.data?.message || err.message || "Failed to load sentiment summary.")
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        fetchSummary();
+    }, [eventId])
+
+    return {
+        summary,
+        loading,
+        error,
+    }
+}


### PR DESCRIPTION
**Summary:**
This pull request introduces the functionality for fetching and displaying sentiment analysis summaries for each event.

**Key changes:**
1. Added _getSentimentSummary(eventId)_ to _EventApi_.
2. Created _useSentimentSummary_ hook.
3. Created _SentimentSummary_ component that displays sentiment breakdown using icons and counts.
4. Embedded _SentimentSummary_ inside _EventCard_.